### PR TITLE
ci: Add PR title validation workflow

### DIFF
--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -1,0 +1,28 @@
+name: "Pull Request Tasks"
+
+on:
+  pull_request:
+    types:
+      [
+        opened,
+        edited,
+        unlocked,
+        labeled,
+        synchronize,
+        reopened,
+        ready_for_review,
+      ]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check-pr-title:
+    name: Check PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR Title
+        uses: deepakputhraya/action-pr-title@v1.0.2
+        with:
+          allowed_prefixes: "feat: ,fix: ,bug: ,ci: ,refactor: ,docs: ,build: ,chore(,deps(,chore: ,feat!: ,fix!: ,refactor!: ,test: " # title should start with the given prefix


### PR DESCRIPTION
# Pull Request

## Description

Adds a new GitHub Actions workflow to validate pull request titles against conventional commit standards. The workflow runs on various pull request events and enforces that titles must begin with allowed prefixes such as:

- feat:
- fix:
- bug:
- ci:
- refactor:
- docs:
- build:
- chore
- deps
- feat!:
- fix!:
- refactor!:
- test:

This ensures consistent and meaningful pull request titles across the project, making change tracking and release notes generation more reliable.

fixes #11