### PR TITLE
ci: Add PR auto-labeller workflow and configuration

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -1,0 +1,56 @@
+# labels auto assigned to PR, keep in sync with labels.yml
+documentation:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["README.md", "docs/**"]
+dependencies:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["**/poetry.lock", "package-lock.json"]
+      - head-branch: ["^dependabot"]
+python:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["*.py", "**/*.py"]
+typescript:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file:
+              [
+                "*.ts",
+                "*.tsx",
+                "**/*.ts",
+                "**/*.tsx",
+                "**/tsconfig.json",
+                "**/**.astro",
+              ]
+just:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["Justfile", "**/*.just"]
+shell:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["**/*.sh"]
+github_actions:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file:
+              [".github/workflows/*", ".github/workflows/**/*"]
+end_to_end_tests:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file:
+              ["tests/end_to_end/*", "tests/end_to_end/**/*"]
+detector:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["detector/**"]
+dashboard:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["dashboard/**"]
+git_hooks:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file: ["githooks/**"]

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -26,3 +26,14 @@ jobs:
         uses: deepakputhraya/action-pr-title@v1.0.2
         with:
           allowed_prefixes: "feat: ,fix: ,bug: ,ci: ,refactor: ,docs: ,build: ,chore(,deps(,chore: ,feat!: ,fix!: ,refactor!: ,test: " # title should start with the given prefix
+
+  labeller:
+    name: Label Pull Request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label Pull Request
+        uses: actions/labeler@v5.0.0
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/other-configurations/labeller.yml
+          sync-labels: true


### PR DESCRIPTION
# Pull Request

## Description

Adds automatic PR labelling based on file changes. Labels will be assigned to pull requests according to the following criteria:

- Documentation: Changes to README or docs folder
- Dependencies: Updates to lock files or dependabot branches
- Python: Changes to Python files
- TypeScript: Changes to TS/TSX/Astro files
- Just: Changes to Justfile or just scripts
- Shell: Changes to shell scripts
- GitHub Actions: Changes to workflow files
- End to End Tests: Changes to E2E test files
- Detector: Changes to detector directory
- Dashboard: Changes to dashboard directory
- Git Hooks: Changes to githooks directory

The labeller runs as part of the pull request tasks workflow using the actions/labeler action.

fixes #13