### PR TITLE
ci: Add PR size labeling workflow

### DIFF
--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -37,3 +37,18 @@ jobs:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/other-configurations/labeller.yml
           sync-labels: true
+
+      - name: Add Size Labels
+        uses: pascalgn/size-label-action@v0.5.5
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          sizes: >
+            {
+              "0": "XS",
+              "40": "S",
+              "100": "M",
+              "200": "L",
+              "800": "XL",
+              "2000": "XXL"
+            }


### PR DESCRIPTION
# Pull Request

## Description

Adds automatic size labelling to pull requests based on the number of lines changed. The following thresholds will apply:

- XS: 0-39 lines
- S: 40-99 lines
- M: 100-199 lines
- L: 200-799 lines
- XL: 800-1999 lines
- XXL: 2000+ lines

This will help quickly identify the scope of changes in pull requests and assist with review prioritisation.

fixes #14