### PR TITLE
ci: Add Justfile format check workflow

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -29,3 +29,18 @@ jobs:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           LINTER_RULES_PATH: .github/super-linter-configurations
+
+  check-justfile-format:
+    name: Check Justfile Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Just
+        uses: extractions/setup-just@v2
+
+      - name: Check Justfile Format
+        run: just just-format-check


### PR DESCRIPTION
# Pull Request

## Description

Added a new GitHub Actions workflow job to verify the formatting of Justfiles. The job runs on Ubuntu and utilises the `just` command-line tool to perform format checking via the `just format-check` command.

This ensures consistent formatting of Justfiles across the project and catches any formatting issues during CI/CD pipeline execution.

fixes #16 