### PR TITLE
ci: Add Automated Markdown Link Checking

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -30,6 +30,24 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           LINTER_RULES_PATH: .github/super-linter-configurations
 
+  check-markdown-links:
+    name: Check Markdown links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Check Markdown links
+        uses: UmbrellaDocs/action-linkspector@v1.2.4
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          config_file: .github/other-configurations/.linkspector.yml
+          reporter: github-pr-review
+          fail_on_error: true
+          filter_mode: nofilter
+
   check-justfile-format:
     name: Check Justfile Format
     runs-on: ubuntu-latest


### PR DESCRIPTION

# Pull Request

<!-- Please use British English for spelling and terminology where possible. However, if you're more comfortable using another variant don't worry about it! -->

## Description

This pull request introduces a new job to the GitHub Actions workflow for checking Markdown links. Below are the most important changes:

Enhancements to GitHub Actions workflow:

* [`.github/workflows/code-quality.yml`](diffhunk://#diff-22e4cd39aff0d5776e7be7d8a8457193836427c286230ca6836710497dcda0e8R33-R50): Added a new job `check-markdown-links` to validate Markdown links using the `UmbrellaDocs/action-linkspector` action. This job includes steps for checking out the repository and running the link checker with specified configurations.

fixes #27
