### PR TITLE
chore: Track Specific Json Files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+manifest.json linguist-detectable
+package.json linguist-detectable


### PR DESCRIPTION
# Pull Request

<!-- Please use British English for spelling and terminology where possible. However, if you're more comfortable using another variant don't worry about it! -->

## Description

This pull request includes a small change to the `.gitattributes` file. The change makes `manifest.json` and `package.json` files detectable by the linguist tool.

* [`.gitattributes`](diffhunk://#diff-618cd5b83d62060ba3d027e314a21ceaf75d36067ff820db126642944145393eR1-R2): Added `manifest.json` and `package.json` to be linguist-detectable.

fixes #38 