### PR TITLE
ci: Add JavaScript Linting Workflow

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -69,8 +69,8 @@ jobs:
       - name: Check Justfile Format
         run: just just-format-check
 
-  eslint:
-    name: Run ESLint
+  check-javascript-code:
+    name: Check JavaScript Code
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -81,13 +81,13 @@ jobs:
       - name: Setup Dependencies
         uses: ./.github/actions/setup-dependencies
 
+      - name: Check JavaScript Formatting
+        run: just prettier-check
+
       - name: Run ESLint
         env:
           SARIF_ESLINT_IGNORE_SUPPRESSED: "true"
-        run: npx eslint .
-          --config eslint.config.js
-          --format @microsoft/eslint-formatter-sarif
-          --output-file eslint-results.sarif
+        run: just eslint-with-sarif
         continue-on-error: true
 
       - name: Upload analysis results to GitHub

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -10,6 +10,7 @@ permissions:
   contents: read
   packages: read
   statuses: write
+  security-events: write
 
 jobs:
   check-code-quality:

--- a/Justfile
+++ b/Justfile
@@ -27,11 +27,11 @@ eslint-with-sarif:
 
 # Check files are prettier formatted
 prettier-check:
-    prettier . --check
+    npx prettier . --check
 
 # Format files with prettier
 prettier-format:
-    prettier . --check --write
+    npx prettier . --check --write
 
 # ------------------------------------------------------------------------------
 # Justfile

--- a/Justfile
+++ b/Justfile
@@ -18,6 +18,9 @@ eslint-check:
 eslint-fix:
     npx eslint . --fix
 
+eslint-with-sarif:
+    npx eslint . --config eslint.config.js --format @microsoft/eslint-formatter-sarif --output-file eslint-results.sarif
+
 # ------------------------------------------------------------------------------
 # Prettier
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
# Pull Request

## Description

This pull request involves changes to the code quality workflow and the `Justfile` to streamline JavaScript code checks and formatting. The most important changes include renaming the ESLint job, adding a Prettier check, and defining a new `just` command for ESLint with SARIF formatting.

Changes to code quality workflow:

* [`.github/workflows/code-quality.yml`](diffhunk://#diff-22e4cd39aff0d5776e7be7d8a8457193836427c286230ca6836710497dcda0e8L72-R73): Renamed the ESLint job from `eslint` to `check-javascript-code` for clarity.
* [`.github/workflows/code-quality.yml`](diffhunk://#diff-22e4cd39aff0d5776e7be7d8a8457193836427c286230ca6836710497dcda0e8R84-R90): Added a new step to check JavaScript formatting using Prettier.
* [`.github/workflows/code-quality.yml`](diffhunk://#diff-22e4cd39aff0d5776e7be7d8a8457193836427c286230ca6836710497dcda0e8R84-R90): Updated the ESLint step to use a `just` command for running ESLint with SARIF formatting.

Changes to `Justfile`:

* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cR21-R23): Added a new `just` command `eslint-with-sarif` to run ESLint with the specified configuration and SARIF formatter.

fixes #50