### PR TITLE
chore: Update Dependabot Schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,10 @@ updates:
       - "/"
       - ".github/actions/setup-dependencies"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "saturday"
+      time: "01:00"
+      timezone: "Europe/London"
     commit-message:
       prefix: "deps(github-actions)"
     target-branch: "main"
@@ -18,7 +21,10 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "saturday"
+      time: "01:00"
+      timezone: "Europe/London"
     commit-message:
       prefix: "deps(javascript)"
     target-branch: "main"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the Dependabot configuration to adjust the update schedule for GitHub Actions and npm dependencies.

Changes to update schedules:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L9-R12): Changed the schedule for GitHub Actions updates from daily to weekly, specifying Saturday at 01:00 in the Europe/London timezone.
* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L21-R27): Changed the schedule for npm updates from daily to weekly, specifying Saturday at 01:00 in the Europe/London timezone.

Fixes #100