### PR TITLE
ci: Add Zizmor Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -103,8 +103,8 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3.27.1
 
-  run-code-limit:
-    name: Run Code Limit
+  run-codelimit:
+    name: Run CodeLimit
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -114,5 +114,30 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
-      - name: "Run Code Limit"
+      - name: "Run CodeLimit"
         uses: getcodelimit/codelimit-action@v1
+
+  run-zizmor:
+    name: Check GitHub Actions with zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v4.2.0
+        with:
+          version: "latest"
+      - name: Run zizmor 🌈
+        run: uvx zizmor --format sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3.27.9
+        with:
+          sarif_file: results.sarif
+          category: zizmor

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -114,6 +114,8 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+      - name: Safe Directory
+        run: git config --global --add safe.directory /github/workspace
       - name: "Run CodeLimit"
         uses: getcodelimit/codelimit-action@v1
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the GitHub Actions workflows to improve code checks and add a new action for checking GitHub Actions with `zizmor`. The most important changes include renaming a job and adding a new job for `zizmor`.

Improvements to GitHub Actions workflows:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L106-R106): Renamed the job `run-code-limit` to `run-codelimit` to correct the job name.
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R119-R143): Added a new job `run-zizmor` to check GitHub Actions using `zizmor`, including steps for checking out the repository, installing `uv`, running `zizmor`, and uploading the SARIF file.

Fixes #115 
