### PR TITLE
chore: Set markdown-link-checker job runner to ubuntu-22.04

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -37,7 +37,7 @@ jobs:
 
   check-markdown-links:
     name: Check Markdown links
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes an update to the `.github/workflows/code-checks.yml` file. The change updates the runner environment for the "Check Markdown links" job.

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L40-R40): Changed the runner environment from `ubuntu-latest` to `ubuntu-22.04` for the "Check Markdown links" job.